### PR TITLE
Update Spanish strings

### DIFF
--- a/AdAway/src/main/res/values-es/strings.xml
+++ b/AdAway/src/main/res/values-es/strings.xml
@@ -127,7 +127,7 @@
   <string name="help_tab_about">Acerca de</string>
   <string name="help_tab_donate">Donar</string>
   <string name="help_tab_s_on_s_off">S-ON/S-OFF</string>
-  <string name="help_tab_faq">Preguntas frecuentes (FAQ)</string>
+  <string name="help_tab_faq">Preguntas frecuentes</string>
   <string name="help_tab_problems">Problemas</string>
   <string name="help_tab_changelog">Registro de cambios</string>
   <string name="help_about_version">Versión:</string>


### PR DESCRIPTION
Remove '(FAQ)' since it breaks tabs design in help menu
![screenshot_20151121-183845](https://cloud.githubusercontent.com/assets/3594924/11319672/512aa600-907f-11e5-9da0-4544ec963afc.png)
